### PR TITLE
Raise ffmpeg subprocess error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can then run the example:
 
 ```bash
 mkdir -p results
-python3 uvq_main.py --input_files='Gaming_1080P-0ce6_orig,20,Gaming_1080P-0ce6_orig.mp4' --output_dir results --model_dir models
+python3 uvq_main.py --input_files="Gaming_1080P-0ce6_orig,20,Gaming_1080P-0ce6_orig.mp4" --output_dir results --model_dir models
 ```
 
 #### Input file formatting
@@ -53,7 +53,7 @@ The input files format is a line with the following fields:
 
 The `output_dir` will contain a csv file with the results for each model. For example,
 ```bash
-cat /tmp/results/mos_ytugc20s_0_Gaming_1080P-0ce6_orig.mp4_orig.csv 
+cat results/mos_ytugc20s_0_Gaming_1080P-0ce6_orig.mp4_orig.csv
 ```
 Gives:
 ```bash

--- a/uvq_utils.py
+++ b/uvq_utils.py
@@ -92,7 +92,7 @@ def load_video(filepath, video_length, transpose=False):
     assert rgb_file.size() >= single_frame_size,  f'Decoding failed to output a single frame: {rgb_file.size()} < {single_frame_size}'
     if rgb_file.size() < full_decode_size:
       logging.warn('Decoding may be truncated: %d bytes (%d frames) < %d bytes (%d frames),'
-                   ' or video length (%ds) may be too short',
+                   ' or video length (%ds) may be too incorrect',
                    rgb_file.size(), rgb_file.size() / single_frame_size,
                    full_decode_size, full_decode_size / single_frame_size,
                    video_length)


### PR DESCRIPTION
Raise ffmpeg subprocess error (which can happen if ffmpeg is missing or file fails to decode).  

Also log if video length is incorrect, and fix up README so that the example works in windows commandline.

Running with incorrect length (e.g,. 21 below):
```
python3 uvq_main.py --input_files='Gaming_1080P-0ce6_orig,21,Gaming_1080P-0ce6_orig.mp4' --output_dir results --model_dir models
```
Will now give a warning:
> WARNING:tensorflow:Decoding may be truncated: 279244800 bytes (101 frames) < 290304000 bytes (105 frames), or video length (21s) may be incorrect.

And running on a **missing_file.mp4**:
```
python3 uvq_main.py --input_files='Gaming_1080P-0ce6_orig,20,missing_file.mp4' --output_dir results --model_dir models
```
Will cause an error:
> subprocess.CalledProcessError: Command 'ffmpeg  -i missing_file.mp4 -filter_complex  "[0:v]scale=w=1280:h=720:flags=bicubic:force_original_aspect_ratio=1,pad=1280:720:(ow-iw)/2:(oh-ih)/2,format=rgb24,split=2[out1][tmp],[tmp]scale=496:496:flags=bilinear[out2]" -map [out1] -r 5 -f rawvideo -pix_fmt rgb24 -y /tmp/tmpcj5sjx7g -map [out2] -r 5 -f rawvideo -pix_fmt rgb24 -y /tmp/tmps67wt6ty' returned non-zero exit status 1.