### PR TITLE
Add batch json output and chunked inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you provide a path to a `.txt` file instead of a video file to the `input` ar
 The `.txt` file should contain one video path per line.
 In batch mode, you must specify an output file using `--output`, which will be populated with `video_basename,score` for each video.
 The `--output_all_stats` flag is ignored in batch mode.
+If you need all statistics in batch mode, use `--batch_json_output` to write the results as json array with the complete statistics and a `video_name` key to identify the source video.
 
 For example, if `video_list.txt` contains:
 ```
@@ -105,12 +106,30 @@ This will create `batch_results.txt` with content like:
 Gaming_1080P-0ce6_orig.mp4,3.880362033843994
 ```
 
+To obtain all statistics in JSON format, use the `--batch_json_output` flag:
+```bash
+python uvq_inference.py video_list.txt --model_version 1.5 --batch_json_output --output batch_results.txt
+```
+
+This will create `batch_results.txt` with content like:
+```json
+[
+  {
+    "uvq1p5_score": 3.880362033843994,
+    "per_frame_scores": [4.021927833557129, 4.013788223266602, 4.110747814178467, 4.142043113708496, 4.1536993980407715, 4.147506237030029, 4.149798393249512, 4.149064064025879, 4.149083137512207, 4.133814811706543, 3.5636682510375977, 3.8045108318328857, 3.630220413208008, 3.6495614051818848, 3.6260201930999756, 3.6136975288391113, 3.5050578117370605, 3.7031033039093018, 3.676196575164795, 3.663726806640625],
+    "frame_indices": [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 360, 390, 420, 450, 480, 510, 540, 570],
+    "video_name": "Gaming_1080P-0ce6_orig.mp4"
+  }
+]
+```
+
 #### Optional Arguments
 
 *   `--transpose`: Transpose the video before processing (e.g., for portrait videos).
 *   `--output OUTPUT`: Path to save the output scores to a file. Scores will be saved in JSON format.
 *   `--device DEVICE`: Device to run inference on (e.g., `cpu` or `cuda`).
 *   `--fps FPS`: (UVQ 1.5 only) Frames per second to sample. Default is 1. Use -1 to sample all frames.
+*   `--batch_json_output`: If specified, outputs batch results in JSON format including per frame scores instead of just overall mean score.
 *   `--output_all_stats`: If specified, print all stats in JSON format to stdout.
 *   `--ffmpeg_path`: Path to FFmpeg executable (default: `ffmpeg`).
 *   `--ffprobe_path`: Path to FFprobe executable (default: `ffprobe`).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ This will create `batch_results.txt` with content like:
 *   `--output OUTPUT`: Path to save the output scores to a file. Scores will be saved in JSON format.
 *   `--device DEVICE`: Device to run inference on (e.g., `cpu` or `cuda`).
 *   `--fps FPS`: (UVQ 1.5 only) Frames per second to sample. Default is 1. Use -1 to sample all frames.
+*   `--chunk_size_frames FRAMES`: (UVQ 1.5 only) Frames to process at once during inference. If you run out of memory reduce this number. Default is 16.
 *   `--batch_json_output`: If specified, outputs batch results in JSON format including per frame scores instead of just overall mean score.
 *   `--output_all_stats`: If specified, print all stats in JSON format to stdout.
 *   `--ffmpeg_path`: Path to FFmpeg executable (default: `ffmpeg`).

--- a/utils/probe.py
+++ b/utils/probe.py
@@ -39,7 +39,7 @@ def get_dimensions(
     result = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         check=True,
         text=True,
     )
@@ -72,7 +72,7 @@ def get_nb_frames(video_path, ffprobe_path="ffprobe") -> int | None:
     result = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         check=True,
         text=True,
     )
@@ -103,7 +103,7 @@ def get_r_frame_rate(video_path, ffprobe_path="ffprobe") -> int | None:
     result = subprocess.run(
         cmd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stderr=subprocess.PIPE,
         check=True,
         text=True,
     )
@@ -137,7 +137,7 @@ def get_video_duration(video_path, ffprobe_path="ffprobe") -> float | None:
   ]
   try:
     result = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
     )
     duration = float(result.stdout)
     return duration

--- a/uvq_inference.py
+++ b/uvq_inference.py
@@ -96,6 +96,7 @@ def run_batch_inference(args):
             fps=fps_to_use,
             orig_fps=orig_fps,
             ffmpeg_path=args.ffmpeg_path,
+            chunk_size_frames=args.chunk_size_frames,
         )
         score = results["uvq1p5_score"]
       elif args.model_version == "1.0":
@@ -176,6 +177,7 @@ def run_single_inference(args):
         fps=fps,
         orig_fps=orig_fps,
         ffmpeg_path=args.ffmpeg_path,
+        chunk_size_frames=args.chunk_size_frames,
     )
   elif args.model_version == "1.0":
     uvq_inference = uvq1p0.UVQ1p0()
@@ -274,6 +276,12 @@ def setup_parser():
       default=1,
       help="Frames per second to sample for UVQ1.5. -1 to sample all frames."
       " Ignored for UVQ1.0.",
+  )
+  parser.add_argument(
+      "--chunk_size_frames",
+      type=int,
+      default=16,
+      help="Number of frames to process in each chunk during inference.",
   )
   parser.add_argument(
       "--batch_json_output",


### PR DESCRIPTION
This also fixes #24 
Main changes are:
* Introduction of an option `--batch_json_output` to output the full result information, including frame scores, when using batch mode.
* Chunked loading and processing of the video.
   This enables processing of longer videos, which would otherwise cause out-of-memory errors.
   A new option `--chunk_size_frames` is added to allow users to set a value that can fit in their GPU memory.